### PR TITLE
Specify Current User on Profile Button

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -48,7 +48,7 @@ const Header = (props: HeaderProps) => {
               <DropdownMenuItem
                 onClick={() =>
                   window.open(
-                    "https://sso.gauchoracing.com/users/348220961155448833/edit",
+                    "https://sso.gauchoracing.com/users/${currentUser.id}/edit",
                     "_blank",
                   )
                 }


### PR DESCRIPTION
Resolves #11 

Specifies the current user when the profile button is clicked following what is done in [Mapache `Header.tsx`](https://github.com/Gaucho-Racing/Mapache/blob/main/dashboard/src/components/Header.tsx)

Should no longer open BK's profile by default