### PR TITLE
Fix URL string interpolation in Profile Button

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -68,7 +68,7 @@ const Header = (props: HeaderProps) => {
               <DropdownMenuItem
                 onClick={() =>
                   window.open(
-                    "https://sso.gauchoracing.com/users/${currentUser.id}/edit",
+                    `https://sso.gauchoracing.com/users/${currentUser.id}/edit`,
                     "_blank",
                   )
                 }


### PR DESCRIPTION
Resolves #15 following #11 

Uses string interpolation instead of double quotes

Small typo that fixes how the profile button works