### PR TITLE
Add More Rows to Purchase Request Table

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -190,7 +190,7 @@ export function DataTable({ data }: DataTableProps) {
     },
     initialState: {
       pagination: {
-        pageSize: 25,
+        pageSize: 20,
       },
     },
   });


### PR DESCRIPTION
The table seems quite small on initial viewing and limiting to 10 rows follows the default of the table, this PR expands it by 2.5 times to 25 while not limiting further PRs to add an option to switch between page rows (by only setting initial state variables).

Currently a full tab screen on a fairly small monitor has a lot of empty space and could be expanded.
<img width="1920" height="1079" alt="image" src="https://github.com/user-attachments/assets/bc8da22d-b6ca-4cc8-b5f8-676036874ab6" />

Note that I have not been able to test, this was made using the relevant documentation.
<img width="544" height="307" alt="image" src="https://github.com/user-attachments/assets/745015ed-3e91-4014-aa78-43ad995f60bd" />